### PR TITLE
Implement printing a bit-image (ESC *)

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -27,7 +27,7 @@ Programmer Manual Commands:
 - [ ] ESC $ nL nH ~ Set absolute print position
 - [ ] ESC % n ~ Select/cancel user-defined character set
 - [ ] ESC & y c1 c2 [x1 d1...d(x×x1)]...[xk d1...d(y×xK)] ~ Define user defined characters
-- [ ] ESC \* m nL nH d1... dk ~ Select bit-image mode
+- [x] ESC \* m nL nH d1... dk ~ Select bit-image mode
 - [ ] ESC - n ~ Turn underline mode on/off
 - [x] ESC 2 ~ Select default line spacing
   - ResetLineSpacing()

--- a/printer.go
+++ b/printer.go
@@ -341,10 +341,13 @@ func (p Printer) PrintImage8(img image.Image, density Density) error {
 		for x := 0; x < imgRect.Max.X; x++ {
 			col := byte(0)
 
-			// Image probably needs to be padded for this stuff
 			for i := 0; i < 8; i++ {
-				c := color.GrayModel.Convert(img.At(x, y+i)).(color.Gray)
 				col <<= 1
+				// Pad the bottom row to be white
+				if y+i > imgRect.Max.Y {
+					continue
+				}
+				c := color.GrayModel.Convert(img.At(x, y+i)).(color.Gray)
 				if c.Y == 0 {
 					col |= 1
 				}
@@ -393,12 +396,16 @@ func (p Printer) PrintImage24(img image.Image, density Density) error {
 		metaRow := []byte{}
 		for x := 0; x < imgRect.Max.X; x++ {
 
-			// Image probably needs to be padded for this stuff
 			for z := 0; z < 3; z++ {
 				col := byte(0)
 				for i := 0; i < 8; i++ {
-					c := color.GrayModel.Convert(img.At(x, (y+z*8)+i)).(color.Gray)
 					col <<= 1
+					// Pad the bottom row to be white
+					if (y+z*8)+i > imgRect.Max.Y {
+						continue
+					}
+
+					c := color.GrayModel.Convert(img.At(x, (y+z*8)+i)).(color.Gray)
 					if c.Y == 0 {
 						col |= 1
 					}

--- a/printer.go
+++ b/printer.go
@@ -3,6 +3,9 @@ package hoin
 import (
 	"fmt"
 	"io"
+	"image"
+	"image/color"
+	"time"
 )
 
 const (
@@ -20,6 +23,14 @@ const (
 	Left   Justification = 0
 	Center Justification = 1
 	Right  Justification = 2
+)
+
+// Density represents the DPI to use when printing images.
+type Density bool
+
+const (
+	SingleDensity Density = false // 90dpi
+	DoubleDensity Density = true  // 180dpi
 )
 
 func checkRange(n, min, max int, info string) error {
@@ -302,5 +313,127 @@ func (p Printer) Justify(j Justification) error {
 	if err != nil {
 		return fmt.Errorf("could not justify: %w", err)
 	}
+	return nil
+}
+
+// PrintImage8 prints an image in the 8-bit row format.  In this format each
+// row is 8 dots tall.
+//
+// The density selects the horizontal DPI of the image.  SingleDensity is
+// 90dpi while DoubleDensity is 180dpi.  Vertical DPI is always 60dpi for
+// 8-bit image data.
+//
+// No black and white conversion is performed on the provided image.  The
+// image should be converted before calling this function.
+func (p Printer) PrintImage8(img image.Image, density Density) error {
+	imgRect := img.Bounds()
+	var err error
+	errMsg := "could not print 8 dot image: %w"
+
+	hd := byte(0)
+	if density {
+		hd = 1
+	}
+
+	// 8 dot density (meta row is 8 dots tall)
+	for y := 0; y < imgRect.Max.Y; y += 8 {
+		row := []byte{}
+		for x := 0; x < imgRect.Max.X; x++ {
+			col := byte(0)
+
+			// Image probably needs to be padded for this stuff
+			for i := 0; i < 8; i++ {
+				c := color.GrayModel.Convert(img.At(x, y+i)).(color.Gray)
+				col <<= 1
+				if c.Y == 0 {
+					col |= 1
+				}
+			}
+
+			row = append(row, col)
+		}
+
+		data := []byte{ESC, '*', hd, byte(len(row)), byte(len(row)>>8)}
+
+		if err = p.SetLineSpacing(0); err != nil {
+			return fmt.Errorf(errMsg, err)
+		}
+		if _, err = p.Write(append(data, row...)); err != nil {
+			return fmt.Errorf(errMsg, err)
+		}
+		if err = p.LF(); err != nil {
+			return fmt.Errorf(errMsg, err)
+		}
+	}
+
+	return nil
+}
+
+// PrintImage24 prints an image in the 24-bit row format.  In this format each
+// row is 24 dots tall.
+//
+// This works the same as PrintImage8() with the only difference being the DPI
+// of the printed image.  SingleDensity is 90dpi while DoubleDensity is
+// 180dpi.  Vertical DPI is always 180dpi for 24-bit image data.
+func (p Printer) PrintImage24(img image.Image, density Density) error {
+	imgRect := img.Bounds()
+	var err error
+	errMsg := "could not print 24 dot image: %w"
+
+	hd := byte(32)
+	if density {
+		hd = 33
+	}
+
+	imgBytes := [][]byte{}
+
+	// First convert the image data to the 1-bit data format.
+	// 24 dot density (meta row is 24 dots tall (3 bytes))
+	for y := 0; y < imgRect.Max.Y; y += 24 {
+		metaRow := []byte{}
+		for x := 0; x < imgRect.Max.X; x++ {
+
+			// Image probably needs to be padded for this stuff
+			for z := 0; z < 3; z++ {
+				col := byte(0)
+				for i := 0; i < 8; i++ {
+					c := color.GrayModel.Convert(img.At(x, (y+z*8)+i)).(color.Gray)
+					col <<= 1
+					if c.Y == 0 {
+						col |= 1
+					}
+				}
+				metaRow = append(metaRow, col)
+			}
+
+		}
+		imgBytes = append(imgBytes, metaRow)
+	}
+
+	// Next send the data to the printer.
+	command := []byte{ESC, 0x2A, hd, byte(imgRect.Max.X), byte(imgRect.Max.X>>8)}
+	for _, row := range imgBytes {
+		err = p.SetLineSpacing(0)
+		if err != nil {
+			return fmt.Errorf(errMsg, err)
+		}
+
+		_, err = p.Write(append(command, row...))
+		if err != nil {
+			return fmt.Errorf(errMsg, err)
+		}
+
+		err = p.LF()
+		if err != nil {
+			return fmt.Errorf(errMsg, err)
+		}
+
+		// If data is sent to fast it won't make it to the printer and will
+		// stop printing part of the way through an image.  This will also
+		// lose any commands sent after the image.  Sleeping for 35ms seems to
+		// be the best balance between not printing and reducing banding.
+		time.Sleep(time.Millisecond * 35)
+	}
+
 	return nil
 }

--- a/printer_test.go
+++ b/printer_test.go
@@ -397,7 +397,7 @@ func TestBeep(t *testing.T) {
 }
 
 func TestJustify(t *testing.T) {
-	for _, j := range []hoin.Justification{hoin.JLeft, hoin.JCenter, hoin.JRight} {
+	for _, j := range []hoin.Justification{hoin.LeftJustify, hoin.CenterJustify, hoin.RightJustify} {
 		t.Run(fmt.Sprint(j), func(t *testing.T) {
 			buffer, printer := newPrinter()
 
@@ -410,7 +410,7 @@ func TestJustify(t *testing.T) {
 }
 
 func TestSetHRIPosition(t *testing.T) {
-	for _, hp := range []hoin.HRIPosition{hoin.HNone, hoin.HAbove, hoin.HBelow, hoin.HBoth} {
+	for _, hp := range []hoin.HRIPosition{hoin.HRINone, hoin.HRIAbove, hoin.HRIBelow, hoin.HRIBoth} {
 		t.Run(fmt.Sprint(hp), func(t *testing.T) {
 			buffer, printer := newPrinter()
 


### PR DESCRIPTION
This adds two functions to print bit images: PrintImage8 and
PrintImage24.  Both functions take an image.Image and a horizontal
density.

Vertical density is always either 60dpi (for PrintImage8) or
180dpi (for PrintImage24).  Horizontal density can be either 90dpi
(SingleDensity) or 180dpi (DoubleDensity).

These functions work on black and white images.  Only black pixels will
print on the page.  Any shade of gray that isn't color.Black is
considered white.